### PR TITLE
Fix typographical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ action: sonnenbatterie.set_em_operating_mode
 mode: 1
 
 Modes:
-- "1": "Manuall",
+- "1": "Manual",
 - "2": "Self Consumption",
 - "6": "Extension Mode",
 - "10": "Time Of Use",


### PR DESCRIPTION
## Summary
- fix a typo in the table of operating modes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688756e32d5c8331878886ec1fe03ad1