### PR TITLE
Add aiofiles and aiohttp requirements

### DIFF
--- a/custom_components/sonnenbatterie/manifest.json
+++ b/custom_components/sonnenbatterie/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": [],
   "config_flow": true,
   "iot_class": "local_polling",
-  "requirements": [],
+  "requirements": ["aiofiles>=0.6.0", "aiohttp>=3.8"],
   "documentation": "https://github.com/mrpointblue/sonnenBatterie-Integration",
   "codeowners": ["@mrpointblue"]
 }


### PR DESCRIPTION
## Summary
- include `aiofiles` and `aiohttp` as requirements in manifest

## Testing
- `git clone` (fails: CONNECT tunnel failed)


------
https://chatgpt.com/codex/tasks/task_e_688781a7c3288331a4a48f5cbaa8bf85